### PR TITLE
Remove mimic joint limit

### DIFF
--- a/robotiq_2f_model/model/robotiq_2f_85.urdf.xacro
+++ b/robotiq_2f_model/model/robotiq_2f_85.urdf.xacro
@@ -262,7 +262,7 @@
 			<parent link="${name}_base"/>
 			<child link="${name}_left_driver"/>
 			<axis xyz="1 0 0"/>
-			<limit lower="${0 * 3.141592 / 180}" upper="${41 * 3.141592 / 180}" effort="176" velocity="${110 * 3.141592 / 180}" />
+			<limit lower="${0 * 3.141592 / 180}" upper="${50 * 3.141592 / 180}" effort="176" velocity="${110 * 3.141592 / 180}" />
 
 			<xacro:unless value="${adaptive_transmission}">
 			<mimic joint="${name}_right_driver_joint" multiplier="1"/>


### PR DESCRIPTION
This change will enable the gripper to reach a fully closed configuration. Since this is a mimic joint, this limit was keeping the _right_driver_joint from reaching its full range and keeping the robotiq from reaching a fully closed configuration.